### PR TITLE
Add Download attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,13 +235,14 @@ Attributes contain tracking values and cover one or more of the
 [Matomo Tracking HTTP API](https://developer.matomo.org/api-reference/tracking-api)
 parameters:
 
-| Attribute | Matomo API parameter |
+| Attribute | Matomo API parameters |
 | --- | --- |
 | `ActionName` | `action_name` |
 | `ApiVersion` (*) | `apiv` |
 | `AuthToken` | `token_auth` |
 | `BotTracking` | `bots` |
 | `CustomAction` | `ca` |
+| `Download` | `download`, `url`, `ca` |
 | `DownloadUrl` | `download` |
 | `Language` | `lang` |
 | `NoResponse` (*) | `send_image` |

--- a/src/Tracking/Attributes/Download.php
+++ b/src/Tracking/Attributes/Download.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pagemachine\MatomoTracking\Tracking\Attributes;
+
+use Pagemachine\MatomoTracking\Tracking\AttributeInterface;
+
+/**
+ * Represents all attributes of a download action
+ */
+final class Download implements AttributeInterface
+{
+    public function __construct(private readonly string $url)
+    {
+    }
+
+    public function toParameters(): \Generator
+    {
+        yield from (new DownloadUrl($this->url))->toParameters();
+        yield from (new Url($this->url))->toParameters();
+        yield from (new CustomAction())->toParameters();
+    }
+}

--- a/tests/Tracking/Attributes/DownloadTest.php
+++ b/tests/Tracking/Attributes/DownloadTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pagemachine\MatomoTracking\Tests\Tracking\Attributes;
+
+use Pagemachine\MatomoTracking\Tracking\Attributes\Download;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DownloadTest extends TestCase
+{
+    #[Test]
+    public function resolvesToParameters(): void
+    {
+        $download = new Download('https://example.org/test.pdf');
+        $expected = [
+            'download' => 'https://example.org/test.pdf',
+            'url' => 'https://example.org/test.pdf',
+            'ca' => 1,
+        ];
+
+        self::assertEquals($expected, iterator_to_array($download->toParameters()));
+    }
+}


### PR DESCRIPTION
This custom attribute combines the "download", "url" and "ca" Matomo API parameters. This is the combination of parameters suggested by the docs for tracking file downloads.