### PR TITLE
Respect server request attributes with custom action factory

### DIFF
--- a/src/Matomo.php
+++ b/src/Matomo.php
@@ -40,7 +40,12 @@ final class Matomo implements InstanceInterface
                 return;
             }
 
+            $attributes = $action->getAttribute('matomo.attributes', []);
             $action = $this->actionFactory->createActionFromRequest($action);
+
+            foreach ($attributes as $attribute) {
+                $action = $action->withAttribute($attribute);
+            }
         }
 
         try {

--- a/src/Tracking/ActionFactory.php
+++ b/src/Tracking/ActionFactory.php
@@ -29,10 +29,6 @@ final class ActionFactory implements ActionFactoryInterface
             ->withAttribute(new Url((string)$serverRequest->getUri()))
             ->withAttribute(new ReferrerUrl($serverRequest->getServerParams()['HTTP_REFERER'] ?? ''));
 
-        foreach ($serverRequest->getAttribute('matomo.attributes', []) as $attribute) {
-            $action = $action->withAttribute($attribute);
-        }
-
         return $action;
     }
 }


### PR DESCRIPTION
Attributes passed with a server request now properly override attributes set by action factories. This became apparent when using custom action factories. In this case the custom action factory decorating the default one was unintentionally able to override attributes passed with the server request.

Now attributes from the server request are passed to the action independent from the internal logic of the action factory.